### PR TITLE
Failsafe socket creation

### DIFF
--- a/META.json
+++ b/META.json
@@ -42,7 +42,7 @@
    "provides" : {
       "Net::Dogstatsd" : {
          "file" : "lib/Net/Dogstatsd.pm",
-         "version" : "v1.0.3"
+         "version" : "v1.0.4"
       }
    },
    "release_status" : "stable",
@@ -58,5 +58,5 @@
          "url" : "https://github.com/jpinkham/net-dogstatsd"
       }
    },
-   "version" : "v1.0.3"
+   "version" : "v1.0.4"
 }

--- a/META.yml
+++ b/META.yml
@@ -19,7 +19,7 @@ name: Net-Dogstatsd
 provides:
   Net::Dogstatsd:
     file: lib/Net/Dogstatsd.pm
-    version: v1.0.3
+    version: v1.0.4
 requires:
   Carp: '0'
   Data::Dumper: '0'
@@ -33,4 +33,4 @@ resources:
   homepage: https://metacpan.org/release/Net-Dogstatsd
   license: http://www.gnu.org/licenses/gpl-3.0.txt
   repository: https://github.com/jpinkham/net-dogstatsd
-version: v1.0.3
+version: v1.0.4

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,7 @@ WriteMakefile
 (
   'PREREQ_PM' => {
                    'Carp' => 0,
-                   'Data::Dumper' => 0
+                   'Data::Dumper' => 0,
                    'Data::Validate::Type' => 0,
                    'LWP::UserAgent' => 0,
                    'Net::Telnet' => 0,

--- a/lib/Net/Dogstatsd.pm
+++ b/lib/Net/Dogstatsd.pm
@@ -21,7 +21,7 @@ Version 1.0.4
 
 =cut
 
-our $VERSION = '1.0.3';
+our $VERSION = '1.0.4';
 
 
 =head1 SYNOPSIS
@@ -198,9 +198,9 @@ sub get_socket
 				PeerAddr => $self->{'host'},
 				PeerPort => $self->{'port'},
 				Proto    => 'udp'
-			) or die 
-				'Could not open UDP connection to ' 
-				. $self->{'host'} . ':' . $self->{'port'} 
+			) or die
+				'Could not open UDP connection to '
+				. $self->{'host'} . ':' . $self->{'port'}
 				. " - $@";
 		}
 		catch

--- a/lib/Net/Dogstatsd.pm
+++ b/lib/Net/Dogstatsd.pm
@@ -17,7 +17,7 @@ Net::Dogstatsd - Perl client to Datadog's dogstatsd metrics collector.
 
 =head1 VERSION
 
-Version 1.0.3
+Version 1.0.4
 
 =cut
 
@@ -198,14 +198,18 @@ sub get_socket
 				PeerAddr => $self->{'host'},
 				PeerPort => $self->{'port'},
 				Proto    => 'udp'
-				)
-			|| die 'Could not open UDP connection to' . $self->{'host'} . ':' . $self->{'port'} . "\n";
-
+			) or die 
+				'Could not open UDP connection to ' 
+				. $self->{'host'} . ':' . $self->{'port'} 
+				. " - $@";
 		}
 		catch
 		{
 			#TODO how to reach this to test it?
-			croak( "Could not open connection to metrics server. Error: >$_<" );
+			# To get here it is possible to provide not resolvable domain or address.
+			# This can happen if application using this module is restarted while DNS
+			# is down or routing is being reconfigured.
+			carp "Could not open connection to metrics server. Error: >$_<";
 		};
 	}
 


### PR DESCRIPTION
All methods that interact with DogStatsd already return if there is no socket. Usually sending metrics is not critical, so nothing bad will happen when socket creation fails, but this still allows to restart application in case there is a temporary network/dns problem, specially when host is provided as domain. This also adds actual IO::Socket::INET error to warning. 